### PR TITLE
Reusing existing connection

### DIFF
--- a/lib/connect-couchbase.js
+++ b/lib/connect-couchbase.js
@@ -101,16 +101,25 @@ module.exports = function(session){
             connectOptions.operationTimeout = options.operationTimeout;
         }
 
-        var Couchbase = require('couchbase');
-        var cluster = new Couchbase.Cluster(connectOptions.host);
-        this.client = cluster.openBucket(connectOptions.bucket, connectOptions.password, function(err) {
-            if (err) {
-                console.log("Could not connect to couchbase with bucket: " + connectOptions.bucket);
-                self.emit('disconnect');
-            } else {
-                self.emit('connect');
-            }
-        });
+        if (options.hasOwnProperty("db")) {
+            connectOptions.db = options.db; // DB Instance
+        }
+
+        if ( typeof(connectOptions.db) != 'undefined' ) {
+            this.client = connectOptions.db;
+        } else {
+            var Couchbase = require('couchbase');
+            var cluster = new Couchbase.Cluster(connectOptions.host);
+
+            this.client = cluster.openBucket(connectOptions.bucket, connectOptions.password, function(err) {
+                if (err) {
+                    console.log("Could not connect to couchbase with bucket: " + connectOptions.bucket);
+                    self.emit('disconnect');
+                } else {
+                    self.emit('connect');
+                }
+            });
+        }
 
         this.client.connectionTimeout = connectOptions.connectionTimeout || 10000;
         this.client.operationTimeout = connectOptions.operationTimeout || 10000;


### PR DESCRIPTION
Hello,

first of all, I would like to thank you for your work writing this module I was looking for something like connect-mongo. It is not exactly what I was expected, but it does the trick ;) So, thank you again.

I saw one thing that was missing and that I have found really good in `connect-mongo`: the fact that you can do the same thing by reusing an existing connection instead of passing over & over the database string.

In a real world app, you might have already instantiated the db by the time you start writing sessions.

```javascript
app.use(session({
    store: new CouchbaseStore({ db: dbInstance })
}));
```

Your default implementation will still work, this is just another feature that will prevent repetition.