### PR TITLE
Touch

### DIFF
--- a/lib/connect-couchbase.js
+++ b/lib/connect-couchbase.js
@@ -101,16 +101,25 @@ module.exports = function(session){
             connectOptions.operationTimeout = options.operationTimeout;
         }
 
-        var Couchbase = require('couchbase');
-        var cluster = new Couchbase.Cluster(connectOptions.host);
-        this.client = cluster.openBucket(connectOptions.bucket, connectOptions.password, function(err) {
-            if (err) {
-                console.log("Could not connect to couchbase with bucket: " + connectOptions.bucket);
-                self.emit('disconnect');
-            } else {
-                self.emit('connect');
-            }
-        });
+        if (options.hasOwnProperty("db")) {
+            connectOptions.db = options.db; // DB Instance
+        }
+
+        if ( typeof(connectOptions.db) != 'undefined' ) {
+            this.client = connectOptions.db;
+        } else {
+            var Couchbase = require('couchbase');
+            var cluster = new Couchbase.Cluster(connectOptions.host);
+
+            this.client = cluster.openBucket(connectOptions.bucket, connectOptions.password, function(err) {
+                if (err) {
+                    console.log("Could not connect to couchbase with bucket: " + connectOptions.bucket);
+                    self.emit('disconnect');
+                } else {
+                    self.emit('connect');
+                }
+            });
+        }
 
         this.client.connectionTimeout = connectOptions.connectionTimeout || 10000;
         this.client.operationTimeout = connectOptions.operationTimeout || 10000;

--- a/lib/connect-couchbase.js
+++ b/lib/connect-couchbase.js
@@ -177,13 +177,18 @@ module.exports = function(session){
         if ('function' !== typeof fn) { fn = noop; }
         sid = this.prefix + sid;
         try {
-            var maxAge = sess.cookie.maxAge
-                , ttl = this.ttl
-                , sess = JSON.stringify(sess);
 
-            ttl = ttl || ('number' == typeof maxAge
-                ? maxAge / 1000 | 0
-                : oneDay);
+            var maxAge = sess.cookie.maxAge
+                , ttl = this.ttl || ('number' == typeof maxAge
+                    ? maxAge / 1000 | 0
+                    : oneDay)
+                ;
+
+            if (ttl > 0) {
+                sess.lastModified = new Date();
+            }
+
+            sess = JSON.stringify(sess);
 
             debug('SETEX "%s" ttl:%s %s', sid, ttl, sess);
             this.client.upsert(sid, sess, {expiry:ttl}, function(err){
@@ -221,17 +226,31 @@ module.exports = function(session){
     CouchbaseStore.prototype.touch = function (sid, sess, fn) {
         if ('function' !== typeof fn) { fn = noop; }
 
-        var maxAge = sess.cookie.maxAge
-            , ttl = this.ttl
-            , sess = JSON.stringify(sess);
-
-        ttl = ttl || ('number' == typeof maxAge
+        var sid = this.prefix + sid
+            , maxAge = sess.cookie.maxAge
+            , ttl = this.ttl || ('number' == typeof maxAge
                 ? maxAge / 1000 | 0
-                : oneDay);
+                : oneDay)
+            , currentDate = new Date()
+            , lastModified = sess.lastModified ? new Date(sess.lastModified).getTime() : 0;
 
+        // if the given options has a touchAfter property, check if the
+        // current timestamp - lastModified timestamp is bigger than
+        // the specified, if it's not, don't touch the session
+        if (ttl > 0 && lastModified > 0) {
 
-        debug('EXPIRE "%s" ttl:%s', sid, ttl);
-        this.client.touch(this.prefix + sid, ttl, fn);
+            var timeElapsed = currentDate.getTime() - lastModified;
+
+            if (timeElapsed > ttl) {
+                sess.lastModified = currentDate;
+            }
+        }
+
+        sess = JSON.stringify(sess);
+        this.client.upsert(sid, sess, {expiry:ttl}, function(err){
+            err || debug('Session Touch complete');
+            fn && fn.apply(this, arguments);
+        });
     };
 
     return CouchbaseStore;


### PR DESCRIPTION
Hello,

I had a strange behaviour on session `expire`. I am using `resave: false` in expression-session because as mentioned in there repository: 

> The default value is true, but using the default has been deprecated, as the default will change in the future. Please research into this setting and choose what is appropriate to your use-case. **Typically, you'll want false**.

ref: https://github.com/expressjs/session/blob/master/README.md#resave

I have added a `lastModified`to check against the `ttl` param. The `expires`will be updated as long as the session is alive, and when it expires, a new session is created.

I attached the message I was getting before my update.
<img width="771" alt="screen shot 2016-05-10 at 01 30 19" src="https://cloud.githubusercontent.com/assets/2272470/15132514/cef8efea-165a-11e6-9419-47c7481a1998.png">

Regards,
Martin-Luther
