### PR TITLE
Added Option to pass in existing client aka bucket

### DIFF
--- a/lib/connect-couchbase.js
+++ b/lib/connect-couchbase.js
@@ -103,7 +103,7 @@ module.exports = function(session){
 
         var Couchbase = require('couchbase');
         var cluster = new Couchbase.Cluster(connectOptions.host);
-        this.client = cluster.openBucket(connectOptions.bucket, connectOptions.password, function(err) {
+        this.client = options.client || cluster.openBucket(connectOptions.bucket, connectOptions.password, function(err) {
             if (err) {
                 console.log("Could not connect to couchbase with bucket: " + connectOptions.bucket);
                 self.emit('disconnect');


### PR DESCRIPTION

refrences:
https://github.com/christophermina/connect-couchbase/compare/master...frank-dspeed:patch-2
https://github.com/christophermina/connect-couchbase/compare/master...frank-dspeed:patch-2

Option for passing in existing bucket via 

~~~
var couchbaseStore = new CouchbaseStore({
    client: cluster.openBucket()
connectionTimeout: 2000,        //optional
    operationTimeout: 2000,         //optional
    cachefile: '',                  //optional
    ttl: 86400,                     //optional
    prefix: 'sess'                  //optional
});

~~~


Example:
~~~
        var Couchbase = require('couchbase');
        var cluster = new Couchbase.Cluster(host);
        var cbInstance = cluster.openBucket(bucket)

        var couchbaseStore = new CouchbaseStore({
            client: cbInstance, // cluster.openBucket()
            connectionTimeout: 2000,        //optional
            operationTimeout: 2000,         //optional
            cachefile: '',                  //optional
            ttl: 86400,                     //optional
            prefix: 'sess'                  //optional
       });


~~~